### PR TITLE
修复input[date]内容不是垂直居中的问题

### DIFF
--- a/css/aui.2.0.css
+++ b/css/aui.2.0.css
@@ -716,7 +716,7 @@ textarea {
     border-radius: 0;
     box-shadow: none;
     display: block;
-    padding: 0;
+    padding: 0.5rem 0;
     margin: 0;
     width: 100%;
     min-height: 2.2rem;


### PR DESCRIPTION
给input标签增加上下内边距0.5rem，该问题只在iOS存在。